### PR TITLE
chore: dev tooling updates and dependency bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,5 @@ tmp/
 third-party/
 
 dist/
+
+.claude/settings.local.json

--- a/.mocharc.min.cjs
+++ b/.mocharc.min.cjs
@@ -1,0 +1,7 @@
+const base = require('./.mocharc.cjs');
+
+module.exports = {
+  ...base,
+  reporter: 'dot',
+  color: false,
+};

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,7 +3,8 @@
     "@release-it/conventional-changelog": {
       "preset": {
         "name": "conventionalcommits",
-        "preMajor": true
+        "preMajor": true,
+        "bumpStrict": true
       },
       "infile": "CHANGELOG.md"
     }
@@ -12,7 +13,9 @@
     "commitMessage": "chore: release v${version} [skip ci]",
     "tagName": "v${version}",
     "push": true,
-    "pushArgs": ["--follow-tags"]
+    "pushArgs": [
+      "--follow-tags"
+    ]
   },
   "github": {
     "release": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "mochaExplorer.esmLoader": true,
+  "mochaExplorer.nodeArgv": [
+    "--import=tsx/esm"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,138 @@
+# CLAUDE.md — @sektek/synaptik-bullmq
+
+BullMQ/Redis job queue transport adapter for `@sektek/synaptik`. Follows the Gateway/Channel duality pattern: `BullMqGateway` processes jobs as events (worker/consumer), `BullMqChannel` enqueues events as jobs (producer).
+
+## Commands
+
+```bash
+npm run build        # Compile (tsc -p tsconfig.build.json)
+npm test             # Run all tests (mocha + tsx/esm)
+npm run test:cover   # Coverage via c8
+
+# Single test file:
+npx mocha --import tsx/esm src/path/to/file.spec.ts
+```
+
+## Source layout
+
+```
+src/
+  types/                          # All TypeScript interfaces and component types
+    bull-mq-service-options.ts
+    job-event-extractor.ts
+    job-name-provider.ts
+    jobs-options-provider.ts
+  bull-mq-channel.ts              # Producer: enqueues events as BullMQ jobs
+  bull-mq-gateway.ts              # Consumer: BullMQ Worker, processes jobs as events
+  *.spec.ts                       # Tests co-located with source
+```
+
+## Classes
+
+### `BullMqChannel<T>`
+
+Enqueues an `Event` as a BullMQ job.
+
+**Key options (`BullMqChannelOptions`):**
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `queue` | required | BullMQ `Queue` instance |
+| `jobNameProvider` | `event.id` | Derives job name from event via `.get` |
+| `jobsOptionsProvider` | sets `jobId: jobName` | Derives `JobsOptions` from event via `.get` |
+
+**Processing flow:**
+```
+send(event) → emit event:received
+            → jobNameProvider(event) → job name
+            → jobsOptionsProvider(event, jobName, options) → job options
+            → queue.add(jobName, event, options)
+            → emit event:delivered + job:created
+            → error: emit event:error, rethrow
+```
+
+**Events emitted:**
+
+| Event | Payload |
+|-------|---------|
+| `event:received` | `(event)` |
+| `event:delivered` | `(event)` |
+| `event:error` | `(error, event)` |
+| `job:created` | `(job)` |
+
+---
+
+### `BullMqGateway<T>`
+
+Creates a BullMQ `Worker` that processes jobs by extracting an `Event` and invoking a handler.
+
+**Key options (`BullMqGatewayOptions`):**
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `handler` | required | Event endpoint to invoke per job |
+| `queueName` / `queue` | — | Queue to consume (at least one required) |
+| `connection` | `localhost:6379` | Redis connection options |
+| `eventExtractor` | `job.data as Event` | Extracts `Event` from `Job` via `.extract` |
+| `workerOptions` | — | Passed to BullMQ `Worker` (excluding `connection`) |
+
+**Processing flow:**
+```
+start() → create Worker(queueName, processor, { ...workerOptions, connection })
+
+per job: emit job:received
+       → eventExtractor(job) → event
+       → emit event:received
+       → handler(event)
+       → success: emit event:processed → Worker emits 'completed' → emit job:completed
+       → error:   emit event:error, rethrow → job fails in BullMQ → emit job:error
+```
+
+**Methods:** `start()`, `stop()` (`stop` is also registered on `SIGINT`/`SIGTERM`)
+
+**Events emitted:**
+
+| Event | Payload |
+|-------|---------|
+| `job:received` | `(job)` |
+| `job:completed` | `(job)` |
+| `job:error` | `(error, job)` |
+| `event:received` | `(event)` |
+| `event:processed` | `(event, result)` |
+| `event:error` | `(error, event)` |
+
+Rethrowing from the processor causes BullMQ to mark the job as failed.
+
+## Types (`src/types/`)
+
+| Type | Description |
+|------|-------------|
+| `JobNameProviderFn<T>` / `JobNameProviderComponent<T>` | Returns job name string from event via `.get` |
+| `JobEventExtractorFn<T>` / `JobEventExtractorComponent<T>` | Extracts `Event` from `Job` via `.extract` |
+| `JobsOptionsProviderFn<T>` / `JobsOptionsProviderComponent<T>` | Returns `JobsOptions` from `(event, jobName?, options?)` via `.get` |
+| `BullMqServiceOptions` | `EventServiceOptions & { queue?, queueName?, connection?, blockingConnection? }` |
+
+## Testing
+
+Tests run against a **real Redis instance** — there is no mock of BullMQ or ioredis.
+
+```bash
+# Connection defaults:
+REDIS_HOST=localhost
+REDIS_PORT=6379
+```
+
+**Patterns:**
+- Queues are created in `before()`, drained in `afterEach()`, obliterated in `after()`
+- `sinon.fake()` for event handlers and providers
+- `sinon.match.has()` for partial object assertions
+- `await new Promise(resolve => setTimeout(resolve, 500))` to allow async Worker processing
+- `sinon.reset()` in `afterEach` clears call history
+
+## Key constraints
+
+- No new dependencies without explicit approval
+- ESM only; imports use `.js` extensions
+- Decorators enabled
+- Depends on `@sektek/synaptik`, `@sektek/utility-belt`, `bullmq`, `ioredis`, `lodash`
+- `workerOptions.connection` is always overridden by the gateway's `connection` option (merged via lodash `_.merge`)

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Library to use @sektek/synaptik with BullMQ
 ## Installation
 
 ```sh
-npm install @sektek/project-name
+npm install @sektek/synaptik-bullmq
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sektek/synaptik": "^0.2.0",
-        "@sektek/utility-belt": "^0.2.3",
+        "@sektek/utility-belt": "^0.3.0",
         "bullmq": "^5.34.1",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.23",
@@ -1716,10 +1716,21 @@
         "uuid": "^13.0.0"
       }
     },
+    "node_modules/@sektek/synaptik/node_modules/@sektek/utility-belt": {
+      "version": "0.2.4",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.2.4/ddfaf1d9db0a43271a0e6e7aabddfa69da3ac792",
+      "integrity": "sha512-28nIRsoAAlDqx97oxU3Pt4MTmUX/ctwoxWkRp6aMDuZ8Z8IkIJBE6iSXMqiO5W7/FzwLX6Xt36EtrZ12Y/PCYg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.23",
+        "tslib": "^2.8.1",
+        "undici-types": "^7.8.0"
+      }
+    },
     "node_modules/@sektek/utility-belt": {
-      "version": "0.2.3",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.2.3/d84eadbb79e42f35c8ea8e4bc65a70b161fbc8ca",
-      "integrity": "sha512-ja4tgUwNKGu7w3raPH4oRvffHD+0bQ49J+SMXXlrLvXCCDCzt6sDJbmvqjB0G9CkDdUvp5XoOtYcqmTHao45rw==",
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.0/a1e4154761248ec60ffb17bcdb23abfbf31e1317",
+      "integrity": "sha512-04lsqSY0oBoZTHE7ComXdV0T3QrsiIJUIY49XWP/A8n+RQjPpGZMPYxH23ffIVTcI5lUg59FFj+TU1Sl3CBUmw==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.23",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "build": "npx tsc -p tsconfig.build.json",
     "lint": "eslint . --cache",
     "test": "mocha",
+    "test:min": "mocha --config .mocharc.min.cjs",
     "test:cover": "c8 npm run test",
     "packages:update": "npm install --package-lock-only --workspaces=false",
     "release": "release-it --ci"
   },
   "dependencies": {
     "@sektek/synaptik": "^0.2.0",
-    "@sektek/utility-belt": "^0.2.3",
+    "@sektek/utility-belt": "^0.3.0",
     "bullmq": "^5.34.1",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.23",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,10 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "ESNext.Array", "ESNext.Iterator"],
     "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -20,6 +19,7 @@
     "noFallthroughCasesInSwitch": true,
     "strictPropertyInitialization": true,
     "esModuleInterop": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "types": ["@types/mocha"]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `test:min` npm script and `.mocharc.min.cjs` for dot-reporter, no-colour test output (for CLI/AI use)
- Bumps `@sektek/utility-belt` to `^0.3.0`
- Extends `tsconfig.json` with `ESNext.Array`/`ESNext.Iterator` libs and `@types/mocha`; removes unused `baseUrl`
- Adds `bumpStrict` to release-it changelog config
- Fixes README install command (was `@sektek/project-name`)
- Adds `CLAUDE.md` with library architecture notes and usage guidance
- Ignores `.claude/settings.local.json`
- Adds `.vscode/settings.json`

## Test plan

- [ ] `npm -w libs/synaptik-bullmq run test:min` produces dot output with no colour
- [ ] `npm -w libs/synaptik-bullmq run build` compiles cleanly
- [ ] `npm -w libs/synaptik-bullmq test` still works with spec reporter