### PR TITLE
SEK-14: Update to AbstractEventComponent (synaptik ^0.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Rethrowing from the processor causes BullMQ to mark the job as failed.
 | `JobNameProviderFn<T>` / `JobNameProviderComponent<T>` | Returns job name string from event via `.get` |
 | `JobEventExtractorFn<T>` / `JobEventExtractorComponent<T>` | Extracts `Event` from `Job` via `.extract` |
 | `JobsOptionsProviderFn<T>` / `JobsOptionsProviderComponent<T>` | Returns `JobsOptions` from `(event, jobName?, options?)` via `.get` |
-| `BullMqServiceOptions` | `EventServiceOptions & { queue?, queueName?, connection?, blockingConnection? }` |
+| `BullMqServiceOptions` | `EventComponentOptions & { queue?, queueName?, connection?, blockingConnection? }` |
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@sektek/synaptik": "^0.2.0",
-        "@sektek/utility-belt": "^0.3.0",
+        "@sektek/synaptik": "^0.3.1",
+        "@sektek/utility-belt": "^0.3.2",
         "bullmq": "^5.34.1",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.23",
@@ -1705,34 +1705,24 @@
       }
     },
     "node_modules/@sektek/synaptik": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/synaptik/0.2.0/562fff4f73eaaac2be89343a691eb636ad70e0a4",
-      "integrity": "sha512-rEHAVpGK79M2nROxm+4jZ9f5gjVLwog/QIkgpDzziFI3wtL/wbo+VtAbsiH29ine+4L/NpYe4ivUOAm+EULicg==",
+      "version": "0.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/synaptik/0.3.1/c3ead1199a68214b12259d21a441e83ed76d3496",
+      "integrity": "sha512-PQrnROjcrOSdTrpYHsv56ckom9miY5HIrwRnB3uCetqd8nFNxMlTdvxPyWHrrq9FMSCAmImE/RLBI4iBcpA28g==",
       "license": "MIT",
       "dependencies": {
-        "@sektek/utility-belt": "^0.2.3",
+        "@sektek/utility-belt": "^0.3.0",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "uuid": "^13.0.0"
       }
     },
-    "node_modules/@sektek/synaptik/node_modules/@sektek/utility-belt": {
-      "version": "0.2.4",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.2.4/ddfaf1d9db0a43271a0e6e7aabddfa69da3ac792",
-      "integrity": "sha512-28nIRsoAAlDqx97oxU3Pt4MTmUX/ctwoxWkRp6aMDuZ8Z8IkIJBE6iSXMqiO5W7/FzwLX6Xt36EtrZ12Y/PCYg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.23",
-        "tslib": "^2.8.1",
-        "undici-types": "^7.8.0"
-      }
-    },
     "node_modules/@sektek/utility-belt": {
-      "version": "0.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.0/a1e4154761248ec60ffb17bcdb23abfbf31e1317",
-      "integrity": "sha512-04lsqSY0oBoZTHE7ComXdV0T3QrsiIJUIY49XWP/A8n+RQjPpGZMPYxH23ffIVTcI5lUg59FFj+TU1Sl3CBUmw==",
+      "version": "0.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.2/ed83bfb0b36e719a4473bbb35ceb683e13224fe7",
+      "integrity": "sha512-uJMdf+RdO/7nJQIPA9c801q5BSADumYX4nmKug20Hg+dnso8hBIMzL50sCxkHe4XxgR1mdFxJ5brLyGRqrleOQ==",
       "license": "MIT",
       "dependencies": {
+        "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "undici-types": "^7.8.0"
@@ -5184,6 +5174,12 @@
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@sektek/synaptik": "^0.3.1",
+        "@sektek/synaptik": "^0.4.0",
         "@sektek/utility-belt": "^0.3.2",
         "bullmq": "^5.34.1",
         "ioredis": "^5.4.1",
@@ -1705,12 +1705,13 @@
       }
     },
     "node_modules/@sektek/synaptik": {
-      "version": "0.3.1",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/synaptik/0.3.1/c3ead1199a68214b12259d21a441e83ed76d3496",
-      "integrity": "sha512-PQrnROjcrOSdTrpYHsv56ckom9miY5HIrwRnB3uCetqd8nFNxMlTdvxPyWHrrq9FMSCAmImE/RLBI4iBcpA28g==",
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/synaptik/0.4.0/a207c2fdd3c3e4baa49098aa0accbd83d0c99b6b",
+      "integrity": "sha512-3lca+qRMWBzCx6RYHR2YXriWzijeirGXrLJ/sykLqegHWgBX2bATIY/jyz3Km9tD0SrXzvPj5jdWYMmsPKUX5w==",
       "license": "MIT",
       "dependencies": {
-        "@sektek/utility-belt": "^0.3.0",
+        "@sektek/utility-belt": "^0.3.2",
+        "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "uuid": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "release": "release-it --ci"
   },
   "dependencies": {
-    "@sektek/synaptik": "^0.2.0",
-    "@sektek/utility-belt": "^0.3.0",
+    "@sektek/synaptik": "^0.3.2",
+    "@sektek/utility-belt": "^0.3.2",
     "bullmq": "^5.34.1",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.23",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "release-it --ci"
   },
   "dependencies": {
-    "@sektek/synaptik": "^0.3.2",
+    "@sektek/synaptik": "^0.4.0",
     "@sektek/utility-belt": "^0.3.2",
     "bullmq": "^5.34.1",
     "ioredis": "^5.4.1",

--- a/src/bull-mq-channel.ts
+++ b/src/bull-mq-channel.ts
@@ -1,10 +1,10 @@
 import {
-  AbstractEventService,
+  AbstractEventComponent,
   EVENT_DELIVERED,
   EVENT_ERROR,
   EVENT_RECEIVED,
   Event,
-  EventServiceOptions,
+  EventComponentOptions,
 } from '@sektek/synaptik';
 import { JobsOptions, Queue } from 'bullmq';
 
@@ -17,7 +17,7 @@ import {
 import { getComponent } from '@sektek/utility-belt';
 
 export type BullMqChannelOptions<T extends Event = Event> =
-  EventServiceOptions & {
+  EventComponentOptions & {
     queue: Queue;
     jobNameProvider?: JobNameProviderComponent<T>;
     jobsOptionsProvider?: JobsOptionsProviderComponent<T>;
@@ -36,7 +36,7 @@ const DEFAULT_JOBS_OPTIONS_PROVIDER: JobsOptionsProviderFn = (
 
 export class BullMqChannel<
   T extends Event = Event,
-> extends AbstractEventService {
+> extends AbstractEventComponent {
   #queue: Queue;
   #jobNameProvider: JobNameProviderFn<T>;
   #jobsOptionsProvider: JobsOptionsProviderFn<T>;

--- a/src/bull-mq-gateway.ts
+++ b/src/bull-mq-gateway.ts
@@ -1,5 +1,5 @@
 import {
-  AbstractEventService,
+  AbstractEventComponent,
   EVENT_ERROR,
   EVENT_PROCESSED,
   EVENT_RECEIVED,
@@ -43,7 +43,7 @@ type BullMqGatewayEvents<T extends Event = Event> = EventHandlerEvents<T> & {
 };
 
 export class BullMqGateway<T extends Event = Event>
-  extends AbstractEventService
+  extends AbstractEventComponent
   implements EventEmittingService<BullMqGatewayEvents<T>>
 {
   #handler: EventHandlerFn<T>;

--- a/src/types/bull-mq-service-options.ts
+++ b/src/types/bull-mq-service-options.ts
@@ -1,7 +1,7 @@
 import { ConnectionOptions, Queue } from 'bullmq';
-import { EventServiceOptions } from '@sektek/synaptik';
+import { EventComponentOptions } from '@sektek/synaptik';
 
-export type BullMqServiceOptions = EventServiceOptions & {
+export type BullMqServiceOptions = EventComponentOptions & {
   queue?: Queue;
   queueName?: string;
   connection?: ConnectionOptions;


### PR DESCRIPTION
## Summary

- Replaces `AbstractEventService` / `EventServiceOptions` with the renamed `AbstractEventComponent` / `EventComponentOptions` from SEK-13
- Updates `BullMqServiceOptions` type accordingly
- Bumps `@sektek/synaptik` dependency to `^0.4.0`

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test:min` passes (requires Redis)